### PR TITLE
Recover baseline compilation against pinned Ya

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,7 @@ import Ya (Object (..), at, this, ho)
 import Ya.Literal
 
 -- Internal modules
-import RVRS.Syntax (Flow, Name)
+import RVRS.Syntax (Flow, Name, nameFromString)
 import RVRS.Parser (parseRVRS)
 import RVRS.Eval (evalIRFlow, EvalError)
 import RVRS.Codegen (prettyPrintFlow)
@@ -50,7 +50,8 @@ main = do
 
               -- Evaluate main flow
               putStrLn "\nEvaluation Output:"
-              evalResult <- evalIRFlow allFlows "main" []
+              let mainName = maybe (error "invalid built-in RVRS name: main") id (nameFromString "main")
+              evalResult <- evalIRFlow allFlows mainName []
 
               case evalResult of
                 Left err -> putStrLn ("Eval Error: " ++ show err)

--- a/app/RunEngine.hs
+++ b/app/RunEngine.hs
@@ -3,7 +3,7 @@ module Main where
 
 import RVRS.Parser (parseRVRS)
 import RVRS.Engine (flowing)
-import RVRS.Syntax (Flow)
+import RVRS.Syntax (Flow, nameFromString)
 import Ya (Object(..))  
 import qualified Data.Text.IO as T
 import qualified Data.Text as Text
@@ -31,5 +31,6 @@ runTestFile path = do
       putStrLn $ errorBundlePretty err
     Right flows -> do
       let flowMap = fromList [(name, flow) | These flow name <- flows]
-      result <- flowing flowMap "main" []
+      let mainName = maybe (error "invalid built-in RVRS name: main") id (nameFromString "main")
+      result <- flowing flowMap mainName []
       putStrLn $ "Result: " -- ++ show result

--- a/src/RVRS/Checker.hs
+++ b/src/RVRS/Checker.hs
@@ -22,7 +22,9 @@ pattern Unexpected x = This (This (That x)) :: Types
 pattern Unsupported x = This (That x) :: Types
 pattern Unknown x = That x :: Types
 
-type Checker = Stops Types `JNT` State Context
+type Checker =
+ State Context `JNT`
+ Stops Types
 
 expression = is @(Recursive Expression `AR_` Checker Typed)
  `li__` literal `ha'he` is `la` variable `ha'he` is

--- a/src/RVRS/Codegen.hs
+++ b/src/RVRS/Codegen.hs
@@ -4,7 +4,7 @@ import Prelude
 import Data.Bool (bool)
 import GHC.IsList (fromList, toList)
 
-import Ya (Object (..), Recursive (..), type T'I' (..), type AR__, type P, pattern Both, is, unwrap, yo, ho, ho'he, hu, la, li)
+import Ya (Object (..), Recursive (..), type AR__, type P, pattern Both, is, unwrap, yo, ho, ho'he, hu, la, li)
 import Ya.Literal ()
 
 import RVRS.Syntax

--- a/src/RVRS/Engine.hs
+++ b/src/RVRS/Engine.hs
@@ -38,7 +38,7 @@ pattern Neglect e = This (That e)
 pattern Defined e = That e
 
 -- type Engine = Given Flowings `JNT` State Bindings `JNT` Stops Reason `JNT` World
-type Engine = World `JNT` Stops Reason `JNT` State Bindings `JNT` Given Flowings
+type Engine = Given Flowings `JNT` State Bindings `JNT` Stops Reason `JNT` World
 
 statement :: Recursive Statement `AR__` Engine Value
 statement x = case unwrap x of

--- a/src/RVRS/Parser/ExprParser.hs
+++ b/src/RVRS/Parser/ExprParser.hs
@@ -4,8 +4,8 @@ import Prelude
 import GHC.IsList (fromList)
 import Control.Monad (void)
 import Control.Monad.Combinators.Expr
+import Data.Char (isAsciiLower, isAsciiUpper)
 import Data.Void
-import Data.String
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
@@ -77,7 +77,13 @@ parens :: Parser a -> Parser a
 parens = between (symbol "(") (symbol ")")
 
 identifier :: Parser Name
-identifier = fromString <$> do lexeme $ (:) <$> lowerChar <*> many letterChar
+identifier = do
+  characters <- lexeme $ (:) <$> satisfy isAsciiLower <*> many (satisfy isAsciiLetter)
+  case nameFromString characters of
+    Just name -> pure name
+    Nothing -> fail "invalid RVRS identifier"
+  where
+    isAsciiLetter character = isAsciiLower character || isAsciiUpper character
 
 stringLiteral :: Parser String
 stringLiteral = char '"' *> manyTill M.charLiteral (char '"')

--- a/src/RVRS/Syntax/Identifier.hs
+++ b/src/RVRS/Syntax/Identifier.hs
@@ -1,6 +1,22 @@
-module RVRS.Syntax.Identifier where
+module RVRS.Syntax.Identifier (type Name, nameFromString) where
 
-import Ya
+import Ya hiding (Maybe)
 import Ya.ASCII
+import Ya.Literal (glyph_to_ascii)
+
+import Data.Char (isAscii, isLetter)
+import GHC.IsList (fromList)
+import Prelude (Maybe (..), String, otherwise, traverse, (&&), (<$>))
 
 type Name = Nonempty List Letter
+
+nameFromString :: String -> Maybe Name
+nameFromString [] = Nothing
+nameFromString characters = fromList <$> traverse letterFromChar characters
+  where
+    letterFromChar character
+      | isAscii character && isLetter character =
+          case glyph_to_ascii character of
+            Letter letter -> Just letter
+            _ -> Nothing
+      | otherwise = Nothing

--- a/tests/engine/identifier_ascii.rvrs
+++ b/tests/engine/identifier_ascii.rvrs
@@ -1,0 +1,4 @@
+flow main {
+  source riverFlow = 1
+  echo riverFlow
+}


### PR DESCRIPTION
Add an explicit RVRS Name conversion boundary, remove the obsolete ExprParser IsString dependency, update executable entry-name construction, remove the obsolete Codegen T'I' constructor import, restore Engine and Checker JNT ordering for pinned Ya, and add an identifier regression fixture.

The library and enabled executables now compile and link. Runtime recovery continues with stdlib identifier reconciliation.